### PR TITLE
Feature display styling/sm

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -13,26 +13,20 @@ class App extends Component {
     super()
     this.state = {
       movieData: [],
-      selectedMovie: null
+      selectedMovie: null,
+      featureMovie: ''
     }
   }
 
   componentDidMount = () => {
     apiData.allMovieData()
-    .then(data => this.setState({movieData: data.movies}))
+    .then(data => this.setState({
+      movieData: data.movies,
+      featureMovie: data.movies[Math.floor(Math.random() * data.movies.length)]}))
     .catch((error) => {
       console.log('Error:', error)
     })
   }
-
-  // randomize = () => {
-  //   console.log(this.state.movieData)
-  //   const randomIndex = Math.floor(Math.random() * this.state.movieData.length);
-  //   const selectedPicture = this.state.movieData[randomIndex]
-  //   // return selectedPicture
-  //   this.setState({ movieData: selectedPicture })
-  //   // console.log(this.state.movieData)
-  // }
 
   showSingleMovie = (id) => {
     const singleMovie = apiData.singleMovieData(id)
@@ -43,15 +37,16 @@ class App extends Component {
   }
 
   showAllMovies = () => {
-    this.setState({ selectedMovie: null })
+    this.setState({
+      selectedMovie: null,
+      featureMovie: this.state.movieData[Math.floor(Math.random() * this.state.movieData.length)] })
   }
 
   render() {
     return (
-      // console.log(movieData)
       <main className='App'>
         <Header />
-        {!this.state.selectedMovie ? <FeatureDisplay movieData={this.state.movieData}/> : null}
+        {!this.state.selectedMovie ? <FeatureDisplay movieData={this.state.featureMovie}/> : null}
         {this.state.selectedMovie ? <MovieInfo movie={this.state.selectedMovie}
         showAllMovies={this.showAllMovies}/> :
         <Movies

--- a/src/FeatureDisplay.css
+++ b/src/FeatureDisplay.css
@@ -1,20 +1,17 @@
 .featureImage {
   height: 100vh;
   width: 100vw;
-  display: block;
-  position: relative;
-  /* background: fixed; */
-  /* margin-top: 0; */
+  background: fixed;
+
 }
 
 .featureDisplay {
-  display: flex;
-  flex-direction: column;
+  position: relative;
 }
 
 h1 {
-  position: fixed;
-  top: 85vh;
+  position: absolute;
+  top: 80vh;
   left: 40vw;
   font-family: 'Questrial';
   font-size: 48px;
@@ -22,9 +19,9 @@ h1 {
 }
 
 h3 {
-  position: fixed;
-  
+  position: absolute;
   text-align: left;
+  top: 1vh;
   margin-left: 2vw;
   font-family: 'Questrial';
   font-size: 30px;

--- a/src/FeatureDisplay.js
+++ b/src/FeatureDisplay.js
@@ -1,54 +1,15 @@
 import React, { Component } from 'react'
 import './FeatureDisplay.css'
 
-const FeatureDisplay  = (movieData) => {
-//   // constructor(props) {
-//   //   super(props)
-//   //   this.state = {
-//   //     movieData: this.props.movieData
-//   //   }
-//   // }
-//
-//   // randomize = () => {
-//     const randomIndex = Math.floor(Math.random() * movieData.length);
-//     const selectedPicture = movieData[randomIndex]
-//     // return selectedPicture
-//
-//
-//   // componentWillMount = () => {
-//   //   this.randomize()
-//   // this.randomize()
-//   // }
-//   // render() {
-//     // console.log(this.state.movieData)
+const FeatureDisplay = ({ movieData }) => {
+
     return (
-      <section className='featureDisplay'>
-        <h3>title</h3>
-        <h1>Rancid Tomatillos</h1>
-        <img className='featureImage' src='' alt='background image for Away movie' />
-      </section>
+        <section className='featureDisplay'>
+          <img className='featureImage' src={movieData.backdrop_path} alt='background image for Away movie' />
+          <h1>Rancid Tomatillos</h1>
+          <h3>{movieData.title}</h3>
+          </section>
     )
   }
-// }
-
-//randomize should go in app.js
-//pass randomize as a prop to feature featureDisplay
-//set randomize to be state of feature dispaly
-//this.state.backdrop_path
-
-// randomizeFeatureDisplay = ({ movieData }) => {
-  // const randomImages = movieData.movieData
-  // const filteredImages = randomImages.filter(image => {
-  //   return image.backdrop_path
-  // })
-
-    // console.log(randomImages)
-  //
-    // this.setState({ src:  selectedPicture.backdrop_path})
-  // }
-
-  // render() {
-  // }
-// }
 
 export default FeatureDisplay

--- a/src/MovieInfo.css
+++ b/src/MovieInfo.css
@@ -1,9 +1,11 @@
 .movie-backdrop {
-  /* background: cover; */
-  /* position: relative; */
-  /* background:linear-gradient(to bottom,transparent 50%,rgba(0,0,0,.2) 60%,rgba(0,0,0,.7) 100%); */
+  position: relative;
   width: 100vw;
   height: 100vh;
+}
+
+.single-movie-feature-display {
+  position: relative;
 }
 
 .movie-tagline {


### PR DESCRIPTION
# Description
Main page now displays a random movie backdrop and title on load.
Main page also displays a random movie backdrop and title when a user 
navigates back to main page from single movie view.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
- CSS changes to feature display to fix bug where App title and movie title were rolling instead of fixed over feature backdrop.
- CSS changes to fix the same aforementioned issue, but with single movie view.
- Added a new prop to state called featureMovie to make it possible to have a randomized featured movie on page load.

Motivation for this fix comes from our desire to accurately match our wireframe and inspiration from Apple.tv+ and generate a random 'showcase' movie on page load.

## List any issues this closes
No issues.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor
- [ ] Documentation update

## Check the correct box

- [x] This broke nothing
- [ ] This broke some stuff
- [ ] This broke everything

## Checklist:

- [ ] I have linked the appropriate Project Board in this PR
- [x] My code follows the style guidelines of this project
- [x] My code has no unused/commented out code
- [x] I have performed a self-review of my code
- [ ] I have fully tested my code